### PR TITLE
auto recover routine to avoid sentinel interrupt main process.

### DIFF
--- a/util/auto_recover.go
+++ b/util/auto_recover.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sentinel-group/sentinel-golang/logging"
+)
+
+func WithRecoverGo(f func(), logger *logging.SentinelLogger) {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Errorf("Panic:%+v.", errors.Errorf("%+v", err))
+		}
+	}()
+	f()
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"github.com/sentinel-group/sentinel-golang/logging"
+	"testing"
+)
+
+func TestWithRecoverGo(t *testing.T) {
+	go WithRecoverGo(func() {
+		panic("internal error!\n")
+	}, logging.GetDefaultLogger())
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Add util function: WithRecoverGo,  in order to avoid sentinel interrupt main process when internal panic.

### Does this pull request fix one issue?
None

### Describe how you did it
None

### Describe how to verify it
None

### Special notes for reviews
None