### PR TITLE
Add metric log implementation

### DIFF
--- a/core/base/metric_item_test.go
+++ b/core/base/metric_item_test.go
@@ -1,0 +1,30 @@
+package base
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMetricItemFromFatStringLegal(t *testing.T) {
+	line1 := "1564382218000|2019-07-29 14:36:58|/foo/*|4|9|3|0|25|0|2|1"
+	item1, err := MetricItemFromFatString(line1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1564382218000), item1.Timestamp)
+	assert.Equal(t, uint64(4), item1.PassQps)
+	assert.Equal(t, uint64(9), item1.BlockQps)
+	assert.Equal(t, uint64(3), item1.CompleteQps)
+	assert.Equal(t, uint64(0), item1.ErrorQps)
+	assert.Equal(t, uint64(25), item1.AvgRt)
+	assert.Equal(t, "/foo/*", item1.Resource)
+	assert.Equal(t, int32(1), item1.Classification)
+}
+
+func TestMetricItemFromFatStringIllegal(t *testing.T) {
+	line1 := "1564382218000|2019-07-29 14:36:58|foo|baz|4|9|3|0|25|0|2|1"
+	_, err := MetricItemFromFatString(line1)
+	assert.Error(t, err, "Error should occur when parsing malformed line")
+
+	line2 := "1564382218000|2019-07-29 14:36:58|foo|-3|9|3|0|25|0|2|1"
+	_, err = MetricItemFromFatString(line2)
+	assert.Error(t, err, "Error should occur when parsing malformed line")
+}

--- a/core/log/metric/aggregator.go
+++ b/core/log/metric/aggregator.go
@@ -1,0 +1,144 @@
+package metric
+
+import (
+	"github.com/sentinel-group/sentinel-golang/core/base"
+	"github.com/sentinel-group/sentinel-golang/core/config"
+	"github.com/sentinel-group/sentinel-golang/core/stat"
+	"github.com/sentinel-group/sentinel-golang/logging"
+	"github.com/sentinel-group/sentinel-golang/util"
+	"sort"
+	"sync"
+	"time"
+)
+
+type metricTimeMap = map[uint64][]*base.MetricItem
+
+const (
+	logFlushQueueSize = 60
+)
+
+var (
+	logger = logging.GetDefaultLogger()
+
+	lastFetchTime int64 = -1
+	writeChan           = make(chan metricTimeMap, logFlushQueueSize)
+	stopChan            = make(chan struct{})
+
+	metricWriter MetricLogWriter
+	initOnce     sync.Once
+)
+
+func InitTask() {
+	initOnce.Do(func() {
+		var err error
+		metricWriter, err = NewDefaultMetricLogWriter(config.MetricLogSingleFileMaxSize(), config.MetricLogMaxFileAmount())
+		if err != nil {
+			logger.Errorf("Failed to initialize the MetricLogWriter: %+v", err)
+			return
+		}
+
+		// Schedule the log flushing task
+		go util.RunWithRecover(writeTaskLoop, logger)
+		// Schedule the log aggregating task
+		flushInterval := config.MetricLogFlushIntervalSec()
+		if flushInterval == 0 {
+			return
+		}
+		ticker := time.NewTicker(time.Duration(flushInterval) * time.Second)
+		go util.RunWithRecover(func() {
+			for {
+				select {
+				case <-ticker.C:
+					doAggregate()
+				case <-stopChan:
+					ticker.Stop()
+					return
+				}
+			}
+		}, logger)
+	})
+}
+
+func writeTaskLoop() {
+	for {
+		select {
+		case m := <-writeChan:
+			keys := make([]uint64, 0, len(m))
+			for t := range m {
+				keys = append(keys, t)
+			}
+			// Sort the time
+			sort.Slice(keys, func(i, j int) bool {
+				return keys[i] < keys[j]
+			})
+
+			for _, t := range keys {
+				err := metricWriter.Write(t, m[t])
+				if err != nil {
+					logger.Errorf("[MetricAggregatorTask] Write metric error: %+v", err)
+				}
+			}
+		}
+	}
+}
+
+func doAggregate() {
+	curTime := util.CurrentTimeMillis()
+	curTime = curTime - curTime%1000
+
+	if int64(curTime) <= lastFetchTime {
+		return
+	}
+	maps := make(metricTimeMap, 0)
+	cns := stat.ResourceNodeList()
+	for _, node := range cns {
+		metrics := currentMetricItems(node, curTime)
+		aggregateIntoMap(maps, metrics, node)
+	}
+	// Aggregate for inbound entrance node.
+	aggregateIntoMap(maps, currentMetricItems(stat.InboundNode(), curTime), stat.InboundNode())
+
+	// Update current last fetch timestamp.
+	lastFetchTime = int64(curTime)
+
+	if len(maps) > 0 {
+		writeChan <- maps
+	}
+}
+
+func aggregateIntoMap(mm metricTimeMap, metrics map[uint64]*base.MetricItem, node *stat.ResourceNode) {
+	for t, item := range metrics {
+		item.Resource = node.ResourceName()
+		item.Classification = int32(node.ResourceType())
+		items, exists := mm[t]
+		if exists {
+			mm[t] = append(items, item)
+		} else {
+			mm[t] = []*base.MetricItem{item}
+		}
+	}
+}
+
+func isActiveMetricItem(item *base.MetricItem) bool {
+	return item.PassQps > 0 || item.BlockQps > 0 || item.CompleteQps > 0 || item.ErrorQps > 0 ||
+		item.AvgRt > 0 || item.Concurrency > 0
+}
+
+func isItemTimestampInTime(ts uint64, currentSecStart uint64) bool {
+	// The bucket should satisfy: windowStart between [lastFetchTime, curStart)
+	return int64(ts) >= lastFetchTime && ts < currentSecStart
+}
+
+func currentMetricItems(node *stat.ResourceNode, currentTime uint64) map[uint64]*base.MetricItem {
+	m := make(map[uint64]*base.MetricItem, 2)
+	items := node.MetricsOnCondition(func(ts uint64) bool {
+		return isItemTimestampInTime(ts, currentTime)
+	})
+	for _, item := range items {
+		if !isActiveMetricItem(item) {
+			continue
+		}
+		m[item.Timestamp] = item
+	}
+	return m
+}

--- a/core/log/metric/common.go
+++ b/core/log/metric/common.go
@@ -1,0 +1,123 @@
+package metric
+
+import (
+	"github.com/sentinel-group/sentinel-golang/core/base"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	// MetricFileNameSuffix represents the suffix of the metric file.
+	MetricFileNameSuffix = "metrics.log"
+	// MetricIdxSuffix represents the suffix of the metric index file.
+	MetricIdxSuffix = ".idx"
+	// FileLockSuffix represents the suffix of the lock file.
+	FileLockSuffix = ".lck"
+	// FilePidPrefix represents the pid flag of filename.
+	FilePidPrefix = "pid"
+
+	metricFilePattern = `\.[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]*)?`
+)
+
+var metricFileRegex = regexp.MustCompile(metricFilePattern)
+
+// MetricLogWriter writes and flushes metric items to current metric log.
+type MetricLogWriter interface {
+	Write(ts uint64, items []*base.MetricItem) error
+}
+
+// MetricSearcher searches metric items from the metric log file under given condition.
+type MetricSearcher interface {
+	FindByTimeAndResource(beginTimeMs uint64, endTimeMs uint64, resource string) ([]*base.MetricItem, error)
+
+	FindFromTimeWithMaxLines(beginTimeMs uint64, maxLines uint32) ([]*base.MetricItem, error)
+}
+
+// Generate the metric file name from the service name.
+func FormMetricFileName(serviceName string, withPid bool) string {
+	dot := "."
+	separator := "-"
+	if strings.Contains(serviceName, dot) {
+		serviceName = strings.ReplaceAll(serviceName, dot, separator)
+	}
+	filename := serviceName + separator + MetricFileNameSuffix
+	if withPid {
+		pid := os.Getpid()
+		filename = filename + ".pid" + strconv.Itoa(pid)
+	}
+	return filename
+}
+
+// Generate the metric index filename from the metric log filename.
+func formMetricIdxFileName(metricFilename string) string {
+	return metricFilename + MetricIdxSuffix
+}
+
+func filenameMatches(filename, baseFilename string) bool {
+	if !strings.HasPrefix(filename, baseFilename) {
+		return false
+	}
+	part := filename[len(baseFilename):]
+	// part is like: ".yyyy-MM-dd.number", eg. ".2018-12-24.11"
+	return metricFileRegex.MatchString(part)
+}
+
+func listMetricFilesConditional(baseDir string, filePattern string, predicate func(string, string) bool) ([]string, error) {
+	dir, err := ioutil.ReadDir(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	arr := make([]string, 0)
+	for _, f := range dir {
+		if f.IsDir() {
+			continue
+		}
+		name := f.Name()
+		if predicate(name, filePattern) && !strings.HasSuffix(name, MetricIdxSuffix) && !strings.HasSuffix(name, FileLockSuffix) {
+			// Put the absolute path into the slice.
+			arr = append(arr, filepath.Join(baseDir, name))
+		}
+	}
+	if len(arr) > 1 {
+		sort.Slice(arr, filenameComparator(arr))
+	}
+	return arr, nil
+}
+
+func listMetricFiles(baseDir, filePattern string) ([]string, error) {
+	return listMetricFilesConditional(baseDir, filePattern, filenameMatches)
+}
+
+func filenameComparator(arr []string) func(i, j int) bool {
+	return func(i, j int) bool {
+		name1 := filepath.Base(arr[i])
+		name2 := filepath.Base(arr[j])
+		a1 := strings.Split(name1, `.`)
+		a2 := strings.Split(name2, `.`)
+		dateStr1 := a1[2]
+		dateStr2 := a2[2]
+
+		// in case of file name contains pid, skip it, like Sentinel-Admin-metrics.log.pid22568.2018-12-24
+		if strings.HasPrefix(a1[2], FilePidPrefix) {
+			dateStr1 = a1[3]
+			dateStr2 = a2[3]
+		}
+
+		// compare date first
+		if dateStr1 != dateStr2 {
+			return dateStr1 < dateStr2
+		}
+
+		// same date, compare the file number
+		t := len(name1) - len(name2)
+		if t != 0 {
+			return t < 0
+		}
+		return name1 < name2
+	}
+}

--- a/core/log/metric/common_test.go
+++ b/core/log/metric/common_test.go
@@ -1,0 +1,43 @@
+package metric
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestFormMetricFileName(t *testing.T) {
+	appName1 := "foo-test"
+	appName2 := "foo.test"
+	mf1 := FormMetricFileName(appName1, false)
+	mf2 := FormMetricFileName(appName2, false)
+	assert.Equal(t, "foo-test-metrics.log", mf1)
+	assert.Equal(t, mf1, mf2)
+	mf1Pid := FormMetricFileName(appName2, true)
+	if !strings.HasSuffix(mf1Pid, strconv.Itoa(os.Getpid())) {
+		t.Fatalf("Metric filename <%s> should end with the process id", mf1Pid)
+	}
+}
+
+func TestFilenameComparatorNoPid(t *testing.T) {
+	arr := []string{
+		"metrics.log.2018-03-06",
+		"metrics.log.2018-03-07",
+		"metrics.log.2018-03-07.51",
+		"metrics.log.2018-03-07.10",
+		"metrics.log.2018-03-06.100",
+	}
+	expected := []string{
+		"metrics.log.2018-03-06",
+		"metrics.log.2018-03-06.100",
+		"metrics.log.2018-03-07",
+		"metrics.log.2018-03-07.10",
+		"metrics.log.2018-03-07.51",
+	}
+
+	sort.Slice(arr, filenameComparator(arr))
+	assert.Equal(t, expected, arr)
+}

--- a/core/log/metric/reader.go
+++ b/core/log/metric/reader.go
@@ -1,0 +1,202 @@
+package metric
+
+import (
+	"bufio"
+	"github.com/pkg/errors"
+	"github.com/sentinel-group/sentinel-golang/core/base"
+	"io"
+	"os"
+)
+
+const maxItemAmount = 100000
+
+type MetricLogReader interface {
+	ReadMetrics(nameList []string, fileNo uint32, startOffset uint64, maxLines uint32) ([]*base.MetricItem, error)
+
+	ReadMetricsByEndTime(nameList []string, fileNo uint32, startOffset uint64, beginMs uint64, endMs uint64, resource string) ([]*base.MetricItem, error)
+}
+
+// Not thread-safe itself, but guarded by the outside MetricSearcher.
+type defaultMetricLogReader struct {
+}
+
+func (r *defaultMetricLogReader) ReadMetrics(nameList []string, fileNo uint32, startOffset uint64, maxLines uint32) ([]*base.MetricItem, error) {
+	if len(nameList) == 0 {
+		return make([]*base.MetricItem, 0), nil
+	}
+	// startOffset: the offset of the first file to read
+	items, shouldContinue, err := r.readMetricsInOneFile(nameList[fileNo], startOffset, maxLines, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldContinue {
+		return items, nil
+	}
+	fileNo++
+	// Continue reading until the size or time does not satisfy the condition
+	for {
+		if int(fileNo) >= len(nameList) || len(items) >= int(maxLines) {
+			// No files to read.
+			break
+		}
+		arr, shouldContinue, err := r.readMetricsInOneFile(nameList[fileNo], 0, maxLines, getLatestSecond(items), uint32(len(items)))
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, arr...)
+		if !shouldContinue {
+			break
+		}
+		fileNo++
+	}
+	return items, nil
+}
+
+func (r *defaultMetricLogReader) ReadMetricsByEndTime(nameList []string, fileNo uint32, startOffset uint64, beginMs uint64, endMs uint64, resource string) ([]*base.MetricItem, error) {
+	if len(nameList) == 0 {
+		return make([]*base.MetricItem, 0), nil
+	}
+	// startOffset: the offset of the first file to read
+	items, shouldContinue, err := r.readMetricsInOneFileByEndTime(nameList[fileNo], startOffset, beginMs, endMs, resource, 0)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldContinue {
+		return items, nil
+	}
+	fileNo++
+	// Continue reading until the size or time does not satisfy the condition
+	for {
+		if int(fileNo) >= len(nameList) {
+			// No files to read.
+			break
+		}
+		arr, shouldContinue, err := r.readMetricsInOneFileByEndTime(nameList[fileNo], 0, beginMs, endMs, resource, uint32(len(items)))
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, arr...)
+		if !shouldContinue {
+			break
+		}
+		fileNo++
+	}
+	return items, nil
+}
+
+func (r *defaultMetricLogReader) readMetricsInOneFile(filename string, offset uint64, maxLines uint32, lastSec uint64, prevSize uint32) ([]*base.MetricItem, bool, error) {
+	file, err := openFileAndSeekTo(filename, offset)
+	if err != nil {
+		return nil, false, err
+	}
+	defer file.Close()
+
+	bufReader := bufio.NewReaderSize(file, 8192)
+	items := make([]*base.MetricItem, 0)
+	for {
+		line, err := readLine(bufReader)
+		if err != nil {
+			if err == io.EOF {
+				shouldContinue := prevSize+uint32(len(items)) < maxLines
+				return items, shouldContinue, nil
+			}
+			return nil, false, errors.Wrap(err, "error when reading lines from file")
+		}
+		item, err := base.MetricItemFromFatString(line)
+		if err != nil {
+			logger.Errorf("Failed to convert MetricItem to string: %+v", err)
+			continue
+		}
+		tsSec := item.Timestamp / 1000
+
+		if prevSize+uint32(len(items)) >= maxLines && tsSec != lastSec {
+			return items, false, nil
+		}
+		items = append(items, item)
+		lastSec = tsSec
+	}
+	return items, true, err
+}
+
+func (r *defaultMetricLogReader) readMetricsInOneFileByEndTime(filename string, offset uint64, beginMs uint64, endMs uint64, resource string, prevSize uint32) ([]*base.MetricItem, bool, error) {
+	beginSec := beginMs / 1000
+	endSec := endMs / 1000
+	file, err := openFileAndSeekTo(filename, offset)
+	if err != nil {
+		return nil, false, err
+	}
+	defer file.Close()
+
+	bufReader := bufio.NewReaderSize(file, 8192)
+	items := make([]*base.MetricItem, 0)
+	for {
+		line, err := readLine(bufReader)
+		if err != nil {
+			if err == io.EOF {
+				return items, true, nil
+			}
+			return nil, false, errors.Wrap(err, "error when reading lines from file")
+		}
+		item, err := base.MetricItemFromFatString(line)
+		if err != nil {
+			logger.Errorf("Invalid line of metric file: %s, error: %+v", line, err)
+			continue
+		}
+		tsSec := item.Timestamp / 1000
+		// currentSecond should in [beginSec, endSec]
+		if tsSec < beginSec || tsSec > endSec {
+			return items, false, nil
+		}
+
+		// empty resource name indicates "fetch all"
+		if resource == "" || resource == item.Resource {
+			items = append(items, item)
+		}
+		// Max items limit to avoid infinite reading
+		if len(items)+int(prevSize) >= maxItemAmount {
+			return items, false, nil
+		}
+	}
+	return items, true, nil
+}
+
+func readLine(bufReader *bufio.Reader) (string, error) {
+	buf := make([]byte, 0)
+	for {
+		line, ne, err := bufReader.ReadLine()
+		if err != nil {
+			return "", err
+		}
+		buf = append(buf, line...)
+		if !ne {
+			return string(buf), err
+		}
+		// buffer size < line size, so we need to read until the `ne` flag is false.
+	}
+}
+
+func getLatestSecond(items []*base.MetricItem) uint64 {
+	if items == nil {
+		return 0
+	}
+	return items[len(items)-1].Timestamp / 1000
+}
+
+func openFileAndSeekTo(filename string, offset uint64) (*os.File, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open file: "+filename)
+	}
+
+	// Set position to the offset recorded in the idx file
+	_, err = file.Seek(int64(offset), io.SeekStart)
+	if err != nil {
+		_ = file.Close()
+		return nil, errors.Wrapf(err, "failed to fseek to offset %d", offset)
+	}
+	return file, nil
+}
+
+func newDefaultMetricLogReader() (MetricLogReader, error) {
+	return &defaultMetricLogReader{}, nil
+}

--- a/core/log/metric/searcher.go
+++ b/core/log/metric/searcher.go
@@ -1,0 +1,198 @@
+package metric
+
+import (
+	"encoding/binary"
+	"github.com/pkg/errors"
+	"github.com/sentinel-group/sentinel-golang/core/base"
+	"github.com/sentinel-group/sentinel-golang/util"
+	"io"
+	"os"
+	"sync"
+)
+
+const offsetNotFound = -1
+
+type DefaultMetricSearcher struct {
+	reader MetricLogReader
+
+	baseDir      string
+	baseFilename string
+
+	cachedPos *filePosition
+
+	mux *sync.Mutex
+}
+
+type filePosition struct {
+	metricFilename string
+	idxFilename    string
+
+	curOffsetInIdx uint64
+	curSecInIdx    uint64
+
+	// TODO: cache the idx file handle here?
+}
+
+func (s *DefaultMetricSearcher) FindByTimeAndResource(beginTimeMs uint64, endTimeMs uint64, resource string) ([]*base.MetricItem, error) {
+	return s.searchOffsetAndRead(beginTimeMs, func(filenames []string, fileNo uint32, offset uint64) (items []*base.MetricItem, err error) {
+		return s.reader.ReadMetricsByEndTime(filenames, fileNo, offset, beginTimeMs, endTimeMs, resource)
+	})
+}
+
+func (s *DefaultMetricSearcher) FindFromTimeWithMaxLines(beginTimeMs uint64, maxLines uint32) ([]*base.MetricItem, error) {
+	return s.searchOffsetAndRead(beginTimeMs, func(filenames []string, fileNo uint32, offset uint64) (items []*base.MetricItem, err error) {
+		return s.reader.ReadMetrics(filenames, fileNo, offset, maxLines)
+	})
+}
+
+func (s *DefaultMetricSearcher) searchOffsetAndRead(beginTimeMs uint64, doRead func([]string, uint32, uint64) ([]*base.MetricItem, error)) ([]*base.MetricItem, error) {
+	filenames, err := listMetricFiles(s.baseDir, s.baseFilename)
+	if err != nil {
+		return nil, err
+	}
+	offsetStart, fileNo, err := s.getOffsetStartAndFileIdx(filenames, beginTimeMs)
+	if err != nil {
+		logger.Warnf("Failed to getOffsetStartAndFileIdx, beginTimeMs=%d, error: %+v", beginTimeMs, err)
+	}
+	fileAmount := uint32(len(filenames))
+	for i := fileNo; i < fileAmount; i++ {
+		filename := filenames[i]
+		offset, err := s.findOffsetToStart(filename, beginTimeMs, offsetStart)
+		if err != nil {
+			logger.Warnf("Failed to findOffsetToStart, will try next file. Current beginTimeMs=%d, filename: %s, offsetStart: %d, err: %+v",
+				beginTimeMs, filename, offsetStart, err)
+			continue
+		}
+		if offset >= 0 {
+			return doRead(filenames, fileNo, uint64(offset))
+		}
+	}
+	return make([]*base.MetricItem, 0), nil
+}
+
+func (s *DefaultMetricSearcher) getOffsetStartAndFileIdx(filenames []string, beginTimeMs uint64) (offsetInIdx uint64, i uint32, err error) {
+	cacheOk, err := s.isPositionInTimeFor(beginTimeMs)
+	if err != nil {
+		return
+	}
+	if cacheOk {
+		for j, v := range filenames {
+			if v != s.cachedPos.metricFilename {
+				i = uint32(j)
+				offsetInIdx = s.cachedPos.curOffsetInIdx
+				break
+			}
+		}
+	}
+	return
+}
+
+func (s *DefaultMetricSearcher) findOffsetToStart(filename string, beginTimeMs uint64, lastPos uint64) (int64, error) {
+	s.cachedPos.idxFilename = ""
+	s.cachedPos.metricFilename = ""
+
+	idxFilename := formMetricIdxFileName(filename)
+	if _, err := os.Stat(idxFilename); err != nil {
+		return 0, err
+	}
+	beginSec := beginTimeMs / 1000
+	file, err := os.Open(idxFilename)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to open metric idx file: "+idxFilename)
+	}
+	defer file.Close()
+
+	// Set position to the offset recorded in the idx file
+	_, err = file.Seek(int64(lastPos), io.SeekStart)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to fseek idx to offset %d", lastPos)
+	}
+	curPos, err := util.FilePosition(file)
+	if err != nil {
+		return 0, nil
+	}
+	s.cachedPos.curOffsetInIdx = uint64(curPos)
+	var sec uint64 = 0
+	var offset int64 = 0
+	for {
+		err = binary.Read(file, binary.BigEndian, &sec)
+		if err != nil {
+			if err == io.EOF {
+				// EOF but offset hasn't been found yet, which indicates the expected position is not in current file
+				return offsetNotFound, nil
+			}
+			return 0, err
+		}
+		if sec >= beginSec {
+			break
+		}
+		err = binary.Read(file, binary.BigEndian, &offset)
+		if err != nil {
+			return 0, err
+		}
+		curPos, err := util.FilePosition(file)
+		if err != nil {
+			return 0, nil
+		}
+		s.cachedPos.curOffsetInIdx = uint64(curPos)
+	}
+	err = binary.Read(file, binary.BigEndian, &offset)
+	if err != nil {
+		return 0, err
+	}
+	// Cache the idx filename and position
+	s.cachedPos.metricFilename = filename
+	s.cachedPos.idxFilename = idxFilename
+	s.cachedPos.curSecInIdx = sec
+
+	return offset, nil
+}
+
+func (s *DefaultMetricSearcher) isPositionInTimeFor(beginTimeMs uint64) (bool, error) {
+	if beginTimeMs/1000 < s.cachedPos.curSecInIdx {
+		return false, nil
+	}
+	idxFilename := s.cachedPos.idxFilename
+	if idxFilename == "" {
+		return false, nil
+	}
+	if _, err := os.Stat(idxFilename); err != nil {
+		return false, err
+	}
+	idxFile, err := openFileAndSeekTo(idxFilename, s.cachedPos.curOffsetInIdx)
+	if err != nil {
+		return false, err
+	}
+	defer idxFile.Close()
+
+	var sec uint64
+	err = binary.Read(idxFile, binary.BigEndian, &sec)
+	if err != nil {
+		return false, err
+	}
+
+	return sec == s.cachedPos.curSecInIdx, nil
+}
+
+func NewDefaultMetricSearcher(baseDir, baseFilename string) (MetricSearcher, error) {
+	if baseDir == "" {
+		return nil, errors.New("empty base directory")
+	}
+	if baseFilename == "" {
+		return nil, errors.New("empty base filename pattern")
+	}
+	if baseDir[len(baseDir)-1] != os.PathSeparator {
+		baseDir = baseDir + string(os.PathSeparator)
+	}
+	reader, err := newDefaultMetricLogReader()
+	if err != nil {
+		return nil, err
+	}
+	return &DefaultMetricSearcher{
+		baseDir:      baseDir,
+		baseFilename: baseFilename,
+		reader:       reader,
+		cachedPos:    &filePosition{},
+		mux:          new(sync.Mutex),
+	}, nil
+}

--- a/core/log/metric/writer.go
+++ b/core/log/metric/writer.go
@@ -1,0 +1,298 @@
+package metric
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sentinel-group/sentinel-golang/core/base"
+	"github.com/sentinel-group/sentinel-golang/core/config"
+	"github.com/sentinel-group/sentinel-golang/logging"
+	"github.com/sentinel-group/sentinel-golang/util"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type DefaultMetricLogWriter struct {
+	baseDir      string
+	baseFilename string
+
+	maxSingleSize uint64
+	maxFileAmount uint32
+
+	timezoneOffsetSec int64
+	latestOpSec       int64
+
+	curMetricFile    *os.File
+	curMetricIdxFile *os.File
+
+	metricOut *bufio.Writer
+	idxOut    *bufio.Writer
+
+	mux *sync.RWMutex
+}
+
+func (d *DefaultMetricLogWriter) Write(ts uint64, items []*base.MetricItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	if ts <= 0 {
+		return errors.New(fmt.Sprintf("%s: %d", "Invalid timestamp: ", ts))
+	}
+	if d.curMetricFile == nil || d.curMetricIdxFile == nil {
+		return errors.New("file handle not initialized")
+	}
+	// Update all metric items to the given timestamp.
+	for _, item := range items {
+		item.Timestamp = ts
+	}
+
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	timeSec := int64(ts / 1000)
+	if timeSec < d.latestOpSec {
+		// ignore
+		return nil
+	}
+	if timeSec > d.latestOpSec {
+		pos, err := util.FilePosition(d.curMetricFile)
+		if err != nil {
+			return errors.Wrap(err, "cannot get current pos of the metric file")
+		}
+		if err = d.writeIndex(timeSec, pos); err != nil {
+			return errors.Wrap(err, "cannot write metric idx file")
+		}
+		if d.isNewDay(d.latestOpSec, timeSec) {
+			if err = d.rollToNextFile(ts); err != nil {
+				return errors.Wrap(err, "failed to roll the metric log")
+			}
+		}
+	}
+	// Write and flush
+	if err := d.writeItemsAndFlush(items); err != nil {
+		return errors.Wrap(err, "failed to write and flush metric items")
+	}
+	if err := d.rollFileIfSizeExceeded(ts); err != nil {
+		return errors.Wrap(err, "failed to pre-check the rolling condition of metric logs")
+	}
+	if timeSec > d.latestOpSec {
+		// Update the latest timeSec.
+		d.latestOpSec = timeSec
+	}
+
+	return nil
+}
+
+func (d *DefaultMetricLogWriter) Close() error {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	if d.curMetricIdxFile != nil {
+		d.curMetricIdxFile.Close()
+	}
+	if d.curMetricFile != nil {
+		return d.curMetricFile.Close()
+	}
+	return nil
+}
+
+func (d *DefaultMetricLogWriter) writeItemsAndFlush(items []*base.MetricItem) error {
+	for _, item := range items {
+		s, err := item.ToFatString()
+		if err != nil {
+			logger.Warnf("Failed to convert MetricItem(resource=%s) to string: %+v", item.Resource, err)
+			continue
+		}
+
+		// Append the LF line separator.
+		bs := []byte(s + "\n")
+		_, err = d.metricOut.Write(bs)
+		if err != nil {
+			return nil
+		}
+	}
+	return d.metricOut.Flush()
+}
+
+func (d *DefaultMetricLogWriter) rollFileIfSizeExceeded(time uint64) error {
+	if d.curMetricFile == nil {
+		return nil
+	}
+	stat, err := d.curMetricFile.Stat()
+	if err != nil {
+		return err
+	}
+	if uint64(stat.Size()) >= d.maxSingleSize {
+		return d.rollToNextFile(time)
+	}
+	return nil
+}
+
+func (d *DefaultMetricLogWriter) rollToNextFile(time uint64) error {
+	newFilename, err := d.nextFileNameOfTime(time)
+	if err != nil {
+		return err
+	}
+	return d.closeCurAndNewFile(newFilename)
+}
+
+func (d *DefaultMetricLogWriter) writeIndex(time, offset int64) error {
+	out := d.idxOut
+	if out == nil {
+		return errors.New("index buffered writer not ready")
+	}
+
+	// Use BigEndian here to keep consistent with DataOutputStream in Java.
+	err := binary.Write(out, binary.BigEndian, time)
+	if err != nil {
+		return err
+	}
+	err = binary.Write(out, binary.BigEndian, offset)
+	if err != nil {
+		return err
+	}
+	return out.Flush()
+}
+
+func (d *DefaultMetricLogWriter) removeDeprecatedFiles() error {
+	files, err := listMetricFiles(d.baseDir, d.baseFilename)
+	if err != nil || len(files) == 0 {
+		return err
+	}
+	amountToRemove := len(files) - int(d.maxFileAmount) + 1
+	for i := 0; i < amountToRemove; i++ {
+		filename := files[i]
+		idxFilename := formMetricIdxFileName(filename)
+		err = os.Remove(filename)
+		if err != nil {
+			logger.Errorf("[MetricWriter] Failed to remove metric log file <%s>: %+v", filename, err)
+		} else {
+			logger.Infof("[MetricWriter] Metric log file removed: %s", filename)
+		}
+
+		err = os.Remove(idxFilename)
+		if err != nil {
+			logger.Errorf("[MetricWriter] Failed to remove metric log file <%s>: %+v", idxFilename, err)
+		} else {
+			logger.Infof("[MetricWriter] Metric index file removed: %s", idxFilename)
+		}
+	}
+	return err
+}
+
+func (d *DefaultMetricLogWriter) nextFileNameOfTime(time uint64) (string, error) {
+	dateStr := util.FormatDate(time)
+	filePattern := d.baseFilename + "." + dateStr
+	list, err := listMetricFilesConditional(d.baseDir, filePattern, func(fn string, p string) bool {
+		return strings.Contains(fn, p)
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(list) == 0 {
+		return d.baseDir + filePattern, nil
+	}
+	last := list[len(list)-1]
+	var n uint32 = 0
+	items := strings.Split(last, ".")
+	if len(items) > 0 {
+		v, err := strconv.ParseUint(items[len(items)-1], 10, 32)
+		if err == nil {
+			n = uint32(v)
+		}
+	}
+	return fmt.Sprintf("%s%s.%d", d.baseDir, filePattern, n+1), nil
+}
+
+func (d *DefaultMetricLogWriter) closeCurAndNewFile(filename string) error {
+	err := d.removeDeprecatedFiles()
+	if err != nil {
+		return err
+	}
+
+	if d.curMetricFile != nil {
+		if err = d.curMetricFile.Close(); err != nil {
+			logger.Errorf("[MetricWriter] Failed to close metric log file <%s>: %+v", d.curMetricFile.Name(), err)
+		}
+	}
+	if d.curMetricIdxFile != nil {
+		if err = d.curMetricIdxFile.Close(); err != nil {
+			logger.Errorf("[MetricWriter] Failed to close metric index file <%s>: %+v", d.curMetricIdxFile.Name(), err)
+		}
+	}
+	// Create new metric log file, whether it exists or not.
+	mf, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	logger.Infof("[MetricWriter] New metric log file created: " + filename)
+
+	idxFile := formMetricIdxFileName(filename)
+	mif, err := os.Create(idxFile)
+	if err != nil {
+		return err
+	}
+	logger.Infof("[MetricWriter] New metric log index file created: " + idxFile)
+
+	d.curMetricFile = mf
+	d.metricOut = bufio.NewWriter(mf)
+
+	d.curMetricIdxFile = mif
+	d.idxOut = bufio.NewWriter(mif)
+
+	return nil
+}
+
+func (d *DefaultMetricLogWriter) initialize() error {
+	// Create the dir if not exists.
+	err := util.CreateDirIfNotExists(d.baseDir)
+	if err != nil {
+		return err
+	}
+
+	if d.curMetricFile != nil {
+		return nil
+	}
+	ts := util.CurrentTimeMillis()
+	if err := d.rollToNextFile(ts); err != nil {
+		return errors.Wrap(err, "failed to initialize metric log writer")
+	}
+	d.latestOpSec = int64(ts / 1000)
+	return nil
+}
+
+func (d *DefaultMetricLogWriter) isNewDay(lastSec, sec int64) bool {
+	prevDayTs := (lastSec + d.timezoneOffsetSec) / 86400
+	newDayTs := (sec + d.timezoneOffsetSec) / 86400
+	return newDayTs > prevDayTs
+}
+
+func NewDefaultMetricLogWriter(maxSize uint64, maxFileAmount uint32) (MetricLogWriter, error) {
+	return NewDefaultMetricLogWriterOfApp(maxSize, maxFileAmount, config.AppName())
+}
+
+func NewDefaultMetricLogWriterOfApp(maxSize uint64, maxFileAmount uint32, appName string) (MetricLogWriter, error) {
+	if maxSize == 0 || maxFileAmount == 0 {
+		return nil, errors.New("invalid maxSize or maxFileAmount")
+	}
+	_, offset := time.Now().Zone()
+
+	baseDir := logging.LogBaseDir()
+	baseFilename := FormMetricFileName(appName, logging.LogNameWithPid())
+
+	writer := &DefaultMetricLogWriter{
+		maxSingleSize:     maxSize,
+		maxFileAmount:     maxFileAmount,
+		timezoneOffsetSec: int64(offset),
+		latestOpSec:       0,
+		baseDir:           baseDir,
+		baseFilename:      baseFilename,
+		mux:               new(sync.RWMutex),
+	}
+	err := writer.initialize()
+	return writer, err
+}

--- a/core/log/slot.go
+++ b/core/log/slot.go
@@ -13,7 +13,6 @@ func (s *LogSlot) OnEntryPassed(_ *base.EntryContext) {
 
 func (s *LogSlot) OnEntryBlocked(ctx *base.EntryContext, blockError *base.BlockError) {
 	// TODO: write sentinel-block.log here
-	panic("implement me")
 }
 
 func (s *LogSlot) OnCompleted(_ *base.EntryContext) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add Sentinel metric log implementation. For details of the format, see [the document](https://github.com/alibaba/Sentinel/wiki/Metrics#metric-log).

### Does this pull request fix one issue?

Resolves #5 

### Describe how you did it

Add `MetricSearcher` and `MetricWriter` implementation, which are analogous to Java version. The default log directory is `~/logs/csp`.

Note: the design of the interfaces could be improved later.

### Describe how to verify it

- Run the test cases.
- Run the demo and see the output of the metric log.

### Special notes for reviews

Additional unit test cases are needed, but it's hard to test with the actual file. Suggestions are welcome!