### PR TITLE
Add throttling traffic shaping implementation

### DIFF
--- a/core/flow/rule_manager.go
+++ b/core/flow/rule_manager.go
@@ -37,7 +37,7 @@ func init() {
 		return NewTrafficShapingController(NewDefaultTrafficShapingCalculator(rule.Count), NewDefaultTrafficShapingChecker(rule.MetricType), rule)
 	}
 	tcGenFuncMap[Throttling] = func(rule *FlowRule) *TrafficShapingController {
-		return NewTrafficShapingController(NewDefaultTrafficShapingCalculator(rule.Count), NewThrottlingChecker(rule.MaxQueueingTimeMs, rule.Count), rule)
+		return NewTrafficShapingController(NewDefaultTrafficShapingCalculator(rule.Count), NewThrottlingChecker(rule.MaxQueueingTimeMs), rule)
 	}
 }
 

--- a/core/flow/tc_throttling.go
+++ b/core/flow/tc_throttling.go
@@ -2,19 +2,66 @@ package flow
 
 import (
 	"github.com/sentinel-group/sentinel-golang/core/base"
+	"github.com/sentinel-group/sentinel-golang/util"
+	"math"
+	"sync/atomic"
+	"time"
 )
+
+const nanoUnitOffset = time.Second / time.Nanosecond
 
 // ThrottlingChecker limits the time interval between two requests.
 type ThrottlingChecker struct {
-	maxQueueingTimeMs uint32
-	qps               float64
+	maxQueueingTimeNs uint64
+
+	lastPassedTime uint64
+
+	// TODO: support strict mode
+	strict bool
 }
 
-func NewThrottlingChecker(timeoutMs uint32, qps float64) *ThrottlingChecker {
-	return &ThrottlingChecker{maxQueueingTimeMs: timeoutMs, qps: qps}
+func NewThrottlingChecker(timeoutMs uint32) *ThrottlingChecker {
+	return &ThrottlingChecker{
+		maxQueueingTimeNs: uint64(timeoutMs) * util.UnixTimeUnitOffset,
+		lastPassedTime:    0,
+	}
 }
 
-func (c *ThrottlingChecker) DoCheck(node base.StatNode, acquireCount uint32, threshold float64) *base.TokenResult {
-	// TODO
-	panic("implement me")
+func (c *ThrottlingChecker) DoCheck(_ base.StatNode, acquireCount uint32, threshold float64) *base.TokenResult {
+	// Pass when acquire count is less or equal than 0.
+	if acquireCount <= 0 {
+		return base.NewTokenResultPass()
+	}
+	if threshold <= 0 {
+		return base.NewTokenResultBlocked(base.BlockTypeFlow, "Flow")
+	}
+	// Here we use nanosecond so that we could control the queueing time more accurately.
+	curNano := util.CurrentTimeNano()
+	// The interval between two requests (in nanoseconds).
+	interval := uint64(math.Ceil(float64(acquireCount) / threshold * float64(nanoUnitOffset)))
+
+	// Expected pass time of this request.
+	expectedTime := atomic.LoadUint64(&c.lastPassedTime) + interval
+	if expectedTime <= curNano {
+		// Contention may exist here, but it's okay.
+		atomic.StoreUint64(&c.lastPassedTime, curNano)
+		return base.NewTokenResultPass()
+	}
+	estimatedQueueingDuration := atomic.LoadUint64(&c.lastPassedTime) + interval - util.CurrentTimeNano()
+	if estimatedQueueingDuration > c.maxQueueingTimeNs {
+		return base.NewTokenResultBlocked(base.BlockTypeFlow, "Flow")
+	}
+
+	oldTime := atomic.AddUint64(&c.lastPassedTime, interval)
+	estimatedQueueingDuration = oldTime - util.CurrentTimeNano()
+	if estimatedQueueingDuration > c.maxQueueingTimeNs {
+		// Subtract the interval.
+		atomic.AddUint64(&c.lastPassedTime, ^(interval - 1))
+		return base.NewTokenResultBlocked(base.BlockTypeFlow, "Flow")
+	}
+	if estimatedQueueingDuration > 0 {
+		return base.NewTokenResultShouldWait(estimatedQueueingDuration / util.UnixTimeUnitOffset)
+	} else {
+		return base.NewTokenResultShouldWait(0)
+	}
 }

--- a/core/flow/tc_throttling_test.go
+++ b/core/flow/tc_throttling_test.go
@@ -1,0 +1,75 @@
+package flow
+
+import (
+	"github.com/sentinel-group/sentinel-golang/core/base"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestThrottlingChecker_DoCheckNoQueueingSingleThread(t *testing.T) {
+	tc := NewThrottlingChecker(0)
+	var qps float64 = 5
+
+	// The first request will pass.
+	assert.True(t, tc.DoCheck(nil, 1, qps).IsPass())
+
+	for i := 0; i < int(qps); i++ {
+		assert.True(t, tc.DoCheck(nil, 1, qps).IsBlocked())
+	}
+	time.Sleep(time.Duration(1000/int(qps)+10) * time.Millisecond)
+
+	assert.True(t, tc.DoCheck(nil, 1, qps).IsPass())
+	assert.True(t, tc.DoCheck(nil, 1, qps).IsBlocked())
+}
+
+func TestThrottlingChecker_DoCheckSingleThread(t *testing.T) {
+	tc := NewThrottlingChecker(1000)
+	var qps float64 = 5
+	resultList := make([]*base.TokenResult, 0)
+	for i := 0; i < 10; i++ {
+		res := tc.DoCheck(nil, 1, qps)
+		resultList = append(resultList, res)
+	}
+	assert.True(t, resultList[0].IsPass())
+
+	for i := 1; i <= int(qps); i++ {
+		assert.True(t, resultList[i].Status() == base.ResultStatusShouldWait)
+		wt := resultList[i].WaitMs()
+		assert.InEpsilon(t, i*1000/int(qps), wt, 10)
+	}
+	for i := int(qps) + 1; i < 10; i++ {
+		assert.True(t, resultList[i].IsBlocked())
+	}
+}
+
+func TestThrottlingChecker_DoCheckQueueingParallel(t *testing.T) {
+	tc := NewThrottlingChecker(1000)
+	var qps float64 = 5
+
+	assert.True(t, tc.DoCheck(nil, 1, qps).IsPass())
+
+	wg := &sync.WaitGroup{}
+	gc := 24
+	wg.Add(gc)
+
+	var waitCount, blockCount int32 = 0, 0
+	for i := 0; i < gc; i++ {
+		go func() {
+			res := tc.DoCheck(nil, 1, qps)
+			if res.IsBlocked() {
+				atomic.AddInt32(&blockCount, 1)
+			}
+			if res.Status() == base.ResultStatusShouldWait {
+				atomic.AddInt32(&waitCount, 1)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(gc), waitCount+blockCount)
+	// Non-strict mode may not be strictly accurate, so here we tolerate a delta.
+	assert.InEpsilon(t, qps, waitCount, 1)
+}

--- a/util/time.go
+++ b/util/time.go
@@ -22,3 +22,8 @@ func FormatDate(tsMillis uint64) string {
 func CurrentTimeMillis() uint64 {
 	return uint64(time.Now().UnixNano()) / UnixTimeUnitOffset
 }
+
+// Returns the current Unix timestamp in nanoseconds.
+func CurrentTimeNano() uint64 {
+	return uint64(time.Now().UnixNano())
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add throttling traffic shaping implementation based on algorithms like leaky bucket + "virtual queue".

### Does this pull request fix one issue?

Resolves #32 

### Describe how you did it

![throttling](https://github.com/alibaba/Sentinel/wiki/image/uniform-speed-queue.png)

Some considerations:

- We use a timestamp-based "virtual queue" here instead of a real queue that caches the user task.
- To make it more accurate when calculating the interval between two requests (e.g. QPS > 1000), we use nanosecond here rather than millisecond (though the queueing timeout in the flow rule definition is millisecond-based).
- The implementation is not strictly accurate in multi-threaded scenarios due to consideration for performance. We may introduce a "strict mode" in later versions.

### Describe how to verify it

Run the test cases.

Here is a sample rule for integration test:

```go
{
	ID:                1,
	Resource:          "some-test",
	MetricType:        flow.QPS,
	Count:             10,
	ControlBehavior:   flow.Throttling,
	MaxQueueingTimeMs: 500,
}
```

### Special notes for reviews

NONE