### PR TITLE
Add general configuration definition and initialization mechanism

### DIFF
--- a/core/config/entity.go
+++ b/core/config/entity.go
@@ -1,0 +1,96 @@
+package config
+
+import "github.com/pkg/errors"
+
+type Config struct {
+	Version  string
+	Sentinel struct {
+		App struct {
+			// Name represents the name of current running service.
+			Name string
+			// Type indicates the classification of the service (e.g. web service, API gateway).
+			Type int32
+		}
+		Log struct {
+			// Dir represents the log directory path.
+			Dir string
+			// UsePid indicates whether the filename ends with the process ID (PID).
+			UsePid bool
+			// Metric represents the configuration items of the metric log.
+			Metric struct {
+				SingleFileMaxSize uint64
+				MaxFileCount      uint32
+				FlushIntervalSec  uint32
+			}
+		}
+	}
+}
+
+// LogConfig represent the configuration of logging in Sentinel.
+type LogConfig struct {
+	// Dir represents the log directory path.
+	Dir string
+	// UsePid indicates whether the filename ends with the process ID (PID).
+	UsePid bool `yaml:"usePid"`
+	// Metric represents the configuration items of the metric log.
+	Metric MetricLogConfig
+}
+
+// MetricLogConfig represents the configuration items of the metric log.
+type MetricLogConfig struct {
+	SingleFileMaxSize uint64 `yaml:"singleFileMaxSize"`
+	MaxFileCount      uint32 `yaml:"maxFileCount"`
+	FlushIntervalSec  uint32 `yaml:"flushIntervalSec"`
+}
+
+// SentinelConfig represent the general configuration of Sentinel.
+type SentinelConfig struct {
+	App struct {
+		// Name represents the name of current running service.
+		Name string
+		// Type indicates the classification of the service (e.g. web service, API gateway).
+		Type int32
+	}
+	// Log represents configuration items related to logging.
+	Log LogConfig
+}
+
+type Entity struct {
+	// Version represents the format version of the entity.
+	Version string
+
+	Sentinel SentinelConfig
+}
+
+func NewDefaultConfig() *Entity {
+	return &Entity{
+		Version: "v1",
+		Sentinel: SentinelConfig{
+			App: struct {
+				Name string
+				Type int32
+			}{
+				Name: UnknownProjectName,
+				Type: DefaultAppType,
+			},
+			Log: LogConfig{Metric: MetricLogConfig{SingleFileMaxSize: DefaultMetricLogSingleFileMaxSize, MaxFileCount: DefaultMetricLogMaxFileAmount, FlushIntervalSec: DefaultMetricLogFlushIntervalSec}},
+		},
+	}
+}
+
+func checkValid(conf *SentinelConfig) error {
+	if conf == nil {
+		return errors.New("nil config")
+	}
+	if conf.App.Name == "" {
+		return errors.New("app.name cannot be empty")
+	}
+	mc := conf.Log.Metric
+	if mc.MaxFileCount <= 0 {
+		return errors.New("Bad metric log config: maxFileCount <= 0")
+	}
+	if mc.SingleFileMaxSize <= 0 {
+		return errors.New("Bad metric log config: singleFileMaxSize <= 0")
+	}
+	return nil
+}

--- a/core/config/local_storage.go
+++ b/core/config/local_storage.go
@@ -1,37 +1,101 @@
 package config
 
+import (
+	"github.com/sentinel-group/sentinel-golang/logging"
+	"github.com/sentinel-group/sentinel-golang/util"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"strconv"
+)
+
 const (
 	UnknownProjectName = "unknown_go_service"
 
-	LogDirEnvKey     = "SENTINEL_LOG_DIR"
-	LogNamePidEnvKey = "SENTINEL_LOG_USE_PID"
+	ConfFilePathEnvKey = "SENTINEL_CONFIG_FILE_PATH"
 
 	AppNameEnvKey = "SENTINEL_APP_NAME"
 	AppTypeEnvKey = "SENTINEL_APP_TYPE"
 
+	DefaultConfigFilename                    = "sentinel.yml"
 	DefaultAppType                    int32  = 0
 	DefaultMetricLogFlushIntervalSec  uint32 = 1
 	DefaultMetricLogSingleFileMaxSize uint64 = 1024 * 1024 * 50
 	DefaultMetricLogMaxFileAmount     uint32 = 8
 )
 
+var localConf = NewDefaultConfig()
+
+func InitConfig() error {
+	return InitConfigFromFile("")
+}
+
+func InitConfigFromFile(filePath string) error {
+	if util.IsBlank(filePath) {
+		// If the file path is absent, Sentinel will try to resolve it from the system env.
+		filePath = os.Getenv(ConfFilePathEnvKey)
+		if util.IsBlank(filePath) {
+			filePath = DefaultConfigFilename
+		}
+	}
+	err := loadFromYamlFile(filePath)
+	if err != nil {
+		return err
+	}
+	loadFromSystemEnv()
+
+	logger := logging.GetDefaultLogger()
+	logger.Infof("App name resolved: %s", AppName())
+
+	return nil
+}
+
+func loadFromYamlFile(filePath string) error {
+	if filePath == DefaultConfigFilename {
+		if _, err := os.Stat(DefaultConfigFilename); err != nil {
+			return nil
+		}
+	}
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(content, &localConf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func loadFromSystemEnv() {
+	if appName := os.Getenv(AppNameEnvKey); !util.IsBlank(appName) {
+		localConf.Sentinel.App.Name = appName
+	}
+	appTypeStr := os.Getenv(AppTypeEnvKey)
+	appType, err := strconv.ParseInt(appTypeStr, 10, 32)
+	if err != nil {
+
+	} else {
+		localConf.Sentinel.App.Type = int32(appType)
+	}
+}
+
 func AppName() string {
-	// TODO
-	return "ahas-go-service"
+	return localConf.Sentinel.App.Name
 }
 
 func AppType() int32 {
-	return DefaultAppType
+	return localConf.Sentinel.App.Type
 }
 
 func MetricLogFlushIntervalSec() uint32 {
-	return DefaultMetricLogFlushIntervalSec
+	return localConf.Sentinel.Log.Metric.FlushIntervalSec
 }
 
 func MetricLogSingleFileMaxSize() uint64 {
-	return DefaultMetricLogSingleFileMaxSize
+	return localConf.Sentinel.Log.Metric.SingleFileMaxSize
 }
 
 func MetricLogMaxFileAmount() uint32 {
-	return DefaultMetricLogMaxFileAmount
+	return localConf.Sentinel.Log.Metric.MaxFileCount
 }

--- a/util/string.go
+++ b/util/string.go
@@ -1,0 +1,8 @@
+package util
+
+import "strings"
+
+// IsBlank checks whether the given string is blank.
+func IsBlank(s string) bool {
+	return strings.TrimSpace(s) == ""
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Add general configuration definition and mechanism for initializing conf from YAML file and system env.

### Does this pull request fix one issue?

Resolves #23 

### Describe how you did it

The definition overview: https://github.com/sentinel-group/sentinel-golang/issues/23#issuecomment-585093059

Priority: `system env > YAML file`

Users can provide the YAML file path via the `InitConfigFromFile` function or from system env (via `InitConfig` function). If both are absent, Sentinel will try to read conf from `sentinel.yml` in the project directory. If it does not exist, Sentinel will use the conf from system env (only some fundamental items) and default value instead.

**Note**: The functions for logging are separated from the general config to avoid circular dependency. For logging configurations, see https://github.com/sentinel-group/sentinel-golang/blob/master/logging/config.go

Users **SHOULD** initialize the logging first, before any other operations about Sentinel.

### Describe how to verify it

Run the demo.

### Special notes for reviews

NONE